### PR TITLE
Fix in FiniteQuadraticModule for power_subgroup/subset/...

### DIFF
--- a/psage/modules/finite_quadratic_module.py
+++ b/psage/modules/finite_quadratic_module.py
@@ -1008,6 +1008,10 @@ class FiniteQuadraticModule_ambient (AbelianGroup):
         Return the subgroup D_c={ x in D | cx=0}
         
         """
+        if not c in ZZ:
+            raise ValueError("c has to be an integer.")
+        if gcd(c,self.order())==1:
+            return self.subgroup([])
         l=[]
         for x in self:
             y = c*x


### PR DESCRIPTION
In sage 5.10 which I'm still running here in Darmstadt, the power_subgroup and power_subset_star did not work (again)? The patch fixes this and also adds a small efficiency improvement. Please review... Stephan
