### PR TITLE
fix encoding of one file and some bad prints in doctests

### DIFF
--- a/psage/modform/arithgroup/plot_dom.py
+++ b/psage/modform/arithgroup/plot_dom.py
@@ -209,7 +209,7 @@ class HyperbolicTriangle(HyperbolicPolygon):
     Note that constructions should use ``hyperbolic_``::
 
          sage: from sage.plot.hyperbolic_triangle import HyperbolicTriangle
-         sage: print HyperbolicTriangle(0, 1/2, I, {})
+         sage: print(HyperbolicTriangle(0, 1/2, I, {}))
          Hyperbolic triangle (0.000000000000000, 0.500000000000000, 1.00000000000000*I)
 
     Note: The main reason for this extension is that we sometimes want to draw only certain sides of the triangle.
@@ -222,7 +222,7 @@ class HyperbolicTriangle(HyperbolicPolygon):
         Examples::
 
             sage: from sage.plot.hyperbolic_triangle import HyperbolicTriangle
-            sage: print HyperbolicTriangle(0, 1/2, I, {})
+            sage: print(HyperbolicTriangle(0, 1/2, I, {}))
             Hyperbolic triangle (0.000000000000000, 0.500000000000000, 1.00000000000000*I)
 
         """
@@ -281,7 +281,7 @@ class HyperbolicTriangleDisc(object): #]GraphicPrimitive):
         Examples::
         
             sage: from sage.plot.hyperbolic_triangle import HyperbolicTriangle
-            sage: print HyperbolicTriangle(0, 1/2, I, {})
+            sage: print(HyperbolicTriangle(0, 1/2, I, {}))
             Hyperbolic triangle (0.000000000000000, 0.500000000000000, 1.00000000000000*I)
         """
         A, B, C = (CC(A), CC(B), CC(C))

--- a/psage/modules/weil_module.py
+++ b/psage/modules/weil_module.py
@@ -1,4 +1,4 @@
-# -*- coding: iso-8859-1 -*-
+# -*- coding: utf-8 -*-
 #*****************************************************************************
 #       Copyright (C) 2009 Nils-Peter Skoruppa <nils.skoruppa@uni-siegen.de>
 #                          Fredrik Stroemberg <stroemberg@mathematik.tu-darmstadt.de>
@@ -20,12 +20,12 @@ $\rho(A)\rho(B)=\sigma(A,B)\rho(AB)$ where the cocycle $\sigma(A,B)$ is implemen
 
 
 REFERENCES:
- - [St] Fredrik Strömberg, "Weil representations associated to finite quadratic modules", arXiv:1108.0202
+ - [St] Fredrik StrÃ¶mberg, "Weil representations associated to finite quadratic modules", arXiv:1108.0202
  
 
 
  AUTHORS:
-   - Fredrik Strömberg
+   - Fredrik StrÃ¶mberg
    - Nils-Peter Skoruppa
    - Stephan Ehlen
 
@@ -2111,6 +2111,6 @@ def compare_formula_for_one_module(W,nmats=10,verbose=0):
     for i in range(nmats):
         A = SL2Z.random_element()
         t = compare_formula_for_one_matrix(W,A,verbose)
-        if t==False:
+        if not t:
             return False
     return True


### PR DESCRIPTION
one file had a wrong encoding, fix that so that at least one can run "sage -t --force-lib psage"

also fix some python2 prints in some doctests